### PR TITLE
Remove unecessary `__future__` imports

### DIFF
--- a/src/app/api/v1/endpoints/api_keys.py
+++ b/src/app/api/v1/endpoints/api_keys.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status

--- a/src/app/db/migrations/env.py
+++ b/src/app/db/migrations/env.py
@@ -10,8 +10,6 @@ Restrictions enforced here:
     other service's migration history.
 """
 
-from __future__ import annotations
-
 import asyncio
 from logging.config import fileConfig
 

--- a/src/app/db/migrations/script.py.mako
+++ b/src/app/db/migrations/script.py.mako
@@ -5,8 +5,6 @@ Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 
 """
-from __future__ import annotations
-
 from typing import Sequence, Union
 
 from alembic import op

--- a/src/app/db/migrations/versions/20260512_0900_create_ai_api_keys.py
+++ b/src/app/db/migrations/versions/20260512_0900_create_ai_api_keys.py
@@ -10,8 +10,6 @@ Create Date: 2026-05-12 09:00:00.000000
 
 """
 
-from __future__ import annotations
-
 from collections.abc import Sequence
 
 import sqlalchemy as sa

--- a/src/app/db/seeds/api_keys.py
+++ b/src/app/db/seeds/api_keys.py
@@ -14,8 +14,6 @@ Two rows may be seeded:
         set. The raw key is never stored or logged.
 """
 
-from __future__ import annotations
-
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/src/app/db/seeds/runner.py
+++ b/src/app/db/seeds/runner.py
@@ -5,8 +5,6 @@ transaction, and commits. Idempotency is each individual seed's
 responsibility.
 """
 
-from __future__ import annotations
-
 from app.config import get_settings
 from app.database import AsyncSessionLocal
 from app.db.seeds.api_keys import seed_admin_api_keys

--- a/src/app/internal/project.py
+++ b/src/app/internal/project.py
@@ -6,8 +6,6 @@ Access: SELECT only — ai_user has role_ai_reader on the public schema.
 Base:   ExternalBase (from app.db.base) — excluded from Alembic metadata.
 """
 
-from __future__ import annotations
-
 from datetime import datetime
 from typing import Any
 

--- a/src/app/models/api_key.py
+++ b/src/app/models/api_key.py
@@ -5,8 +5,6 @@ Access: full DML — this service creates, updates, and revokes API keys.
 Base:   OwnedBase (from app.db.base).
 """
 
-from __future__ import annotations
-
 import uuid
 from datetime import datetime
 

--- a/src/app/schemas/api_key.py
+++ b/src/app/schemas/api_key.py
@@ -1,6 +1,4 @@
 # src/app/schemas/api_key.py
-from __future__ import annotations
-
 import uuid
 from datetime import datetime
 

--- a/src/app/security/auth.py
+++ b/src/app/security/auth.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from datetime import datetime, timezone
 
 from fastapi import Depends, Request, Security

--- a/src/app/services/api_key.py
+++ b/src/app/services/api_key.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import hashlib
 import secrets
 import uuid

--- a/tests/test_db_seeds.py
+++ b/tests/test_db_seeds.py
@@ -6,8 +6,6 @@ These do not touch a real database — they assert that:
   * Every seed statement uses ON CONFLICT DO NOTHING (idempotency).
 """
 
-from __future__ import annotations
-
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 


### PR DESCRIPTION
This service is using a modern version of Python (3.14) and does not require the use of `__future__` import statements.